### PR TITLE
Feature/plotting feels

### DIFF
--- a/ex_feels/mix.exs
+++ b/ex_feels/mix.exs
@@ -4,7 +4,7 @@ defmodule ExFeels.Mixfile do
   def project do
     [
       app: :ex_feels,
-      version: "0.0.1",
+      version: "1.0.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
       compilers: [:phoenix, :gettext] ++ Mix.compilers,

--- a/py_feels/.gitignore
+++ b/py_feels/.gitignore
@@ -1,1 +1,2 @@
 # WIP scripts
+./binary/training/stacked_training.py

--- a/py_feels/.gitignore
+++ b/py_feels/.gitignore
@@ -1,2 +1,2 @@
 # WIP scripts
-/binary/time_series.py
+#/binary/time_series.py

--- a/py_feels/.gitignore
+++ b/py_feels/.gitignore
@@ -1,2 +1,1 @@
 # WIP scripts
-#/binary/time_series.py

--- a/py_feels/binary/binary_classifier.py
+++ b/py_feels/binary/binary_classifier.py
@@ -2,10 +2,12 @@
 """
 Created on Thu Dec  7 15:45:21 2017
 
-Binary sentiment classifier for BitFeels. Loads model fit by
-binary_classifier_training.py and produces predictions. Currently
-just runs on amazon training data, but will eventually pull from
-mongo DB of tweets and return sentiments
+Binary sentiment classifier for BitFeels. Loads models fit by
+binary_classifier_training.py and produces predictions. Model
+pickle file paths are stored in ./model/model_dict.pckl by the
+training script 
+
+takes one argument: env = "dev" or "prod"
 
 @author: rcehemann
 """

--- a/py_feels/binary/binary_classifier.py
+++ b/py_feels/binary/binary_classifier.py
@@ -30,7 +30,7 @@ else:
 # connect to  SQL database, query for last item in 'tweets' table
 engine = create_engine('postgresql+psycopg2://wojak:@localhost/' + env)
 
-query  = "SELECT id, text FROM tweets"
+query  = "SELECT tweet_id, text FROM tweets"
 tweets = pd.read_sql(query, engine)
 
 query  = "SELECT DISTINCT tweet_id FROM feels"
@@ -38,10 +38,10 @@ classified = pd.read_sql(query, engine)
 
 # determine those unique tweets for which no feels exist
 unclassified = list(
-    set(tweets.id.values) - set(classified.tweet_id.values)
+    set(tweets.tweet_id.values) - set(classified.tweet_id.values)
 )
 
-tweets = tweets[tweets['id'].isin(unclassified)]
+tweets = tweets[tweets['tweet_id'].isin(unclassified)]
 
 # only predict sentiment if there's text data
 if not tweets.text.empty:
@@ -64,7 +64,7 @@ if not tweets.text.empty:
         feels = pd.DataFrame()
         feels['sentiment']   = list(map(str, sentiments))
         feels['classifier']  = name
-        feels['tweet_id']    = tweets.id.values
+        feels['tweet_id']    = tweets.tweet_id.values
 
         # store prediction time
         time_now = str(datetime.datetime.now())

--- a/py_feels/binary/binary_classifier.py
+++ b/py_feels/binary/binary_classifier.py
@@ -30,7 +30,7 @@ else:
 # connect to  SQL database, query for last item in 'tweets' table
 engine = create_engine('postgresql+psycopg2://wojak:@localhost/' + env)
 
-query  = "SELECT tweet_id, text FROM tweets"
+query  = "SELECT id, text FROM tweets"
 tweets = pd.read_sql(query, engine)
 
 query  = "SELECT DISTINCT tweet_id FROM feels"
@@ -38,10 +38,10 @@ classified = pd.read_sql(query, engine)
 
 # determine those unique tweets for which no feels exist
 unclassified = list(
-    set(tweets.tweet_id.values) - set(classified.tweet_id.values)
+    set(tweets.id.values) - set(classified.tweet_id.values)
 )
 
-tweets = tweets[tweets['tweet_id'].isin(unclassified)]
+tweets = tweets[tweets['id'].isin(unclassified)]
 
 # only predict sentiment if there's text data
 if not tweets.text.empty:
@@ -64,7 +64,7 @@ if not tweets.text.empty:
         feels = pd.DataFrame()
         feels['sentiment']   = list(map(str, sentiments))
         feels['classifier']  = name
-        feels['tweet_id']    = tweets.tweet_id.values
+        feels['tweet_id']    = tweets.id.values
 
         # store prediction time
         time_now = str(datetime.datetime.now())

--- a/py_feels/binary/reclassify.py
+++ b/py_feels/binary/reclassify.py
@@ -34,7 +34,7 @@ with open('./model/model_dict.pckl', 'rb') as f:
 
 # connect to  SQL database, query for last item in 'tweets' table
 engine = create_engine('postgresql+psycopg2://wojak:@localhost/' + env)
-query  = "SELECT tweet_id, text FROM tweets"
+query  = "SELECT id, text FROM tweets"
 tweets = pd.read_sql(query, engine)    
 
 # if this is the first model to 
@@ -55,7 +55,7 @@ for name in fitted_models:
     feels = pd.DataFrame()
     feels['sentiment']   = list(map(str, sentiments))
     feels['classifier']  = name
-    feels['tweet_id']    = tweets.tweet_id.values
+    feels['tweet_id']    = tweets.id.values
     
     # store prediction time
     time_now = str(datetime.datetime.now())

--- a/py_feels/binary/reclassify.py
+++ b/py_feels/binary/reclassify.py
@@ -2,6 +2,11 @@
 """
 Created on Sat Jan 13 15:51:35 2018
 
+reclassifies all tweets in the bit_feels database,
+for use only when classifiers have been added or changed.
+
+takes one argument: env = "dev" or "prod"
+
 @author: blenderherad
 """
 

--- a/py_feels/binary/time_series.py
+++ b/py_feels/binary/time_series.py
@@ -2,13 +2,19 @@
 """
 Created on Sat Jan 20 14:50:21 2018
 
-@author: blenderherad
+Pulls feels and tweet times from the bit_feels database and performs
+a time-window average of the sentiments for plotting. pushes means,
+standard devaitions, classifier names and bin times into the 'stats'
+table of bit_feels. Takes two arguments: window and env
+
+window is the width of the time-bin in hours,
+env is "dev" or "prod"
+
+@author: rcehemann
 """
 
 import pandas as pd
 from numpy import linspace, digitize, mean, std
-from bokeh.plotting import figure, show
-from bokeh.palettes import Spectral
 from datetime import datetime
 from sys import argv
 from sqlalchemy import create_engine
@@ -24,7 +30,7 @@ elif argv[2] == "prod":
     window = argv[1]
     env = "bit_feels"
 else:
-    raise EnvironmentError("Environment should be 'dev' or 'prod'")
+    raise EnvironmentError("second argument should be 'dev' or 'prod'")
 
 # set up SQL connection
 engine = create_engine('postgresql+psycopg2://wojak:@localhost/' + env)
@@ -80,7 +86,9 @@ feeltimes.loc[:,'window'] = windows
 times = pd.DataFrame({'time':bins, 'window':list(range(len(bins)))})
 
 # group by classifier and time-window, then compute mean and std-dev for each
-group_stats = feeltimes.groupby(['classifier', 'window'])['sentiment'].apply(mean_and_std)
+group_stats = feeltimes.groupby(['classifier', 'window'])['sentiment'].apply(
+        mean_and_std
+)
 
 # build stats table by iterating through classifiers, copying times
 # splitting mean and std into separate columns then filling NaN values

--- a/py_feels/binary/time_series.py
+++ b/py_feels/binary/time_series.py
@@ -25,10 +25,10 @@ if len(argv) < 2:
     window = 48.
     env = "bit_feels_dev"
 elif len(argv) < 3 or argv[2] == "dev":
-    window = argv[1]
+    window = float(argv[1])
     env = "bit_feels_dev"
 elif argv[2] == "prod":
-    window = argv[1]
+    window = float(argv[1])
     env = "bit_feels"
 else:
     raise EnvironmentError("second argument should be 'dev' or 'prod'")
@@ -54,12 +54,6 @@ def time_bins(times, window):
     strbins = [t.strftime("%a %b %d %H:%M:%S +0000 %Y") for t in strbins]
     return fltbins, strbins
 
-def time_window(times, bins):
-    """
-        partitions times into bins. returns bin assignments
-    """
-    return 
-
 def mean_and_std(times):
     return mean(times), std(times)
 
@@ -68,12 +62,13 @@ engine = create_engine('postgresql+psycopg2://wojak:@localhost/' + env)
 
 query  = "SELECT tweet_id, sentiment, classifier FROM feels"
 feels  = pd.read_sql(query, engine)
-query  = "SELECT created_at, tweet_id FROM tweets"
+query  = "SELECT created_at, id FROM tweets"
 tweets = pd.read_sql(query, engine)
+feels.rename(columns={'tweet_id':'id'}, inplace=True)
 
 # merge on tweet id to get tweet times 
-feeltimes = pd.merge(feels, tweets, on='tweet_id')
-del feels, tweets
+feeltimes = pd.merge(feels, tweets, on='id')
+#del feels, tweets
 
 # transform datetimes to timestamps
 feeltimes['created_at'] = feeltimes.created_at.apply(

--- a/py_feels/binary/time_series.py
+++ b/py_feels/binary/time_series.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Jan 20 14:50:21 2018
+
+@author: blenderherad
+"""
+
+import pandas as pd
+from numpy import linspace, digitize, mean, std
+from bokeh.plotting import figure, show
+from bokeh.palettes import Spectral
+from datetime import datetime
+from sys import argv
+from sqlalchemy import create_engine
+
+# check environment
+if len(argv) < 2 or argv[1] == "dev":
+    env = "bit_feels_dev"
+elif argv[1] == "prod":
+    env = "bit_feels"
+else:
+    raise EnvironmentError("Environment should be 'dev' or 'prod'")
+
+# set up SQL connection
+engine = create_engine('postgresql+psycopg2://wojak:@localhost/' + env)
+
+def ts_to_td(inserted_at):
+    """
+        returns the total elapsed seconds from
+        the timestamp to present time.
+    """
+    return (inserted_at - datetime.now()).total_seconds()
+
+def time_window(times, window=24.):
+    """
+        function to partition a time series
+        into time windows. takes a numerical value
+        in HOURS for the requested time window.
+        bins are statically sized and the number of bins
+        is calcluated based on the earliest timestamp in the db
+    """
+    t_min  = min(times.values)
+    t_max  = max(times.values)
+    n_bins = int((t_max - t_min) / 3600 / window)
+    bins   = linspace(t_min, t_max, num=n_bins)
+    windows = digitize(times, bins)
+    bins = [datetime.fromtimestamp(t) for t in bins]
+    print(len(bins))
+    return windows, bins
+
+def mean_and_std(times):
+    return mean(times), std(times)
+
+query  = "SELECT tweet_id, sentiment, classifier FROM feels"
+feels  = pd.read_sql(query, engine)
+query  = "SELECT inserted_at, tweet_id FROM tweets"
+tweets = pd.read_sql(query, engine)
+
+# merge on tweet id to get tweet times 
+feeltimes = pd.merge(feels, tweets, on='tweet_id')
+del feels, tweets
+
+# prep the feels for binning
+feeltimes = feeltimes[feeltimes['sentiment'] != "0"].reset_index(drop=True)
+feeltimes.loc[:,'sentiment'] = feeltimes.sentiment.apply(lambda x: int(x))
+
+stats = pd.DataFrame()
+feeltimes['inserted_at'] = feeltimes.inserted_at.apply(
+        lambda x: x.timestamp()
+)
+
+windows, bins = time_window(feeltimes.loc[:,'inserted_at'], window=48)
+if 'time' not in stats.keys():
+    stats['time'] = bins
+    stats['window'] = list(range(len(bins)))
+feeltimes.loc[:,'window'] = windows
+
+tmp_frame = feeltimes.groupby(['classifier', 'window'])['sentiment'].apply(mean_and_std)
+#results = results.add_suffix('_count').reset_index()
+    
+#p1 = figure(x_axis_type = "datetime", title="Sentiment over time", tools='lasso_select')    
+#ml_x = [clf_frames[key].inserted_at for key in clf_frames.keys()]
+#ml_y = [clf_frames[key].sentiment for key in clf_frames.keys()]
+#p1.multi_line(ml_x, ml_y, line_color=Spectral[len(ml_x)])
+#p1.scatter([1,2,3,4,5],[2,3,1,4,5])
+#show(p1)

--- a/py_feels/binary/time_series.py
+++ b/py_feels/binary/time_series.py
@@ -18,6 +18,7 @@ from dateutil import parser
 from numpy import linspace, digitize, mean, std
 from datetime import datetime
 from sys import argv
+from math import ceil
 from sqlalchemy import create_engine
 
 # check environment, parse arguments
@@ -48,7 +49,7 @@ def time_bins(times, window):
     """
     t_min  = min(times)
     t_max  = max(times)
-    n_bins = int((t_max - t_min) / 3600 / window)
+    n_bins = ceil((t_max - t_min) / 3600 / window)
     fltbins = linspace(t_min, t_max, num=n_bins)
     strbins = [datetime.fromtimestamp(t) for t in fltbins]
     strbins = [t.strftime("%a %b %d %H:%M:%S +0000 %Y") for t in strbins]
@@ -68,7 +69,7 @@ feels.rename(columns={'tweet_id':'id'}, inplace=True)
 
 # merge on tweet id to get tweet times 
 feeltimes = pd.merge(feels, tweets, on='id')
-del feels, tweets
+#del feels, tweets
 
 # transform datetimes to timestamps
 feeltimes['created_at'] = feeltimes.created_at.apply(

--- a/py_feels/binary/time_series.py
+++ b/py_feels/binary/time_series.py
@@ -22,17 +22,12 @@ from math import ceil
 from sqlalchemy import create_engine
 
 # check environment, parse arguments
-if len(argv) < 2:
-    window = 48.
+if len(argv) < 2 or argv[1] == "dev":
     env = "bit_feels_dev"
-elif len(argv) < 3 or argv[2] == "dev":
-    window = float(argv[1])
-    env = "bit_feels_dev"
-elif argv[2] == "prod":
-    window = float(argv[1])
+elif argv[1] == "prod":
     env = "bit_feels"
 else:
-    raise EnvironmentError("second argument should be 'dev' or 'prod'")
+    raise EnvironmentError("Environment should be 'dev' or 'prod'")
 
 def ts_to_td(created_at):
     """
@@ -77,7 +72,7 @@ feeltimes['created_at'] = feeltimes.created_at.apply(
 )
 
 # compute time bins, store string labels in data frame
-fltbins, strbins = time_bins(feeltimes.created_at.values, window)
+fltbins, strbins = time_bins(feeltimes.created_at.values, 48.)
 times = pd.DataFrame({'time':strbins, 'window':list(range(len(strbins)))})
 
 # prep the feels for binning

--- a/py_feels/binary/time_series.py
+++ b/py_feels/binary/time_series.py
@@ -95,12 +95,3 @@ for clf in feeltimes.classifier.unique():
 
 # write predictions to 'feels' table in database
 stats.to_sql('stats', engine, if_exists='replace', index=False)
-
-#results = results.add_suffix('_count').reset_index()
-    
-#p1 = figure(x_axis_type = "datetime", title="Sentiment over time", tools='lasso_select')    
-#ml_x = [clf_frames[key].inserted_at for key in clf_frames.keys()]
-#ml_y = [clf_frames[key].sentiment for key in clf_frames.keys()]
-#p1.multi_line(ml_x, ml_y, line_color=Spectral[len(ml_x)])
-#p1.scatter([1,2,3,4,5],[2,3,1,4,5])
-#show(p1)

--- a/py_feels/binary/time_series.py
+++ b/py_feels/binary/time_series.py
@@ -68,7 +68,7 @@ feels.rename(columns={'tweet_id':'id'}, inplace=True)
 
 # merge on tweet id to get tweet times 
 feeltimes = pd.merge(feels, tweets, on='id')
-#del feels, tweets
+del feels, tweets
 
 # transform datetimes to timestamps
 feeltimes['created_at'] = feeltimes.created_at.apply(

--- a/py_feels/binary/time_series.py
+++ b/py_feels/binary/time_series.py
@@ -69,7 +69,7 @@ feels.rename(columns={'tweet_id':'id'}, inplace=True)
 
 # merge on tweet id to get tweet times 
 feeltimes = pd.merge(feels, tweets, on='id')
-#del feels, tweets
+del feels, tweets
 
 # transform datetimes to timestamps
 feeltimes['created_at'] = feeltimes.created_at.apply(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31669884/35778913-065f5b7c-0993-11e8-91c8-fadceebefa27.png)

time-binned statistics are now pushed to SQL 'stats' table with the following format:

```
             classifier   mean     std                       time
 0            LinearSVC  -1.0  0.000000 2017-12-30 19:42:28.908000
 1            LinearSVC   0.0  0.000000 2018-01-01 23:52:04.607125
 2            LinearSVC   0.0  0.000000 2018-01-04 04:01:40.306250
 3            LinearSVC   0.0  0.000000 2018-01-06 08:11:16.005375
```
etc.

time_series.py should be called as follows:

```
python time_series.py window env
```
window is a numerical value giving the width of time bins in hours. env is "dev" or "prod" as before. with no arguments the script defaults to window=48, env='dev'

Since tweets pulled from twitter are not necessarily sequential in time, and we want to assess the average sentiment _at the time of tweeting_, the script recalculates bin average at every call. In the future we may be able to find a safe cutoff for which bins do not have to be recalculated, but this shouldn't be an issue until the database is very large.

For now, since the non-neutral sentiments are quite rare, a single _fetch and feel_ can have significant impact on the bin averages. Down the road it may be best to run time_series.py after every ten or so fetch and feels.
