### PR TITLE
Unique Index for PSQL

### DIFF
--- a/ex_feels/priv/repo/migrations/20171215022040_create_table_tweets.exs
+++ b/ex_feels/priv/repo/migrations/20171215022040_create_table_tweets.exs
@@ -3,7 +3,7 @@ defmodule ExFeels.Repo.Migrations.CreateTableTweets do
 
   def change do
     create table("tweets") do
-      add :text, :string
+      add :text, :string, size: 500
       add :retweet_count, :integer
       add :lang, :string
       add :tweet_id, :bigserial
@@ -14,6 +14,6 @@ defmodule ExFeels.Repo.Migrations.CreateTableTweets do
       timestamps()
     end
 
-    unique_index("tweets", [:tweet_id])
+    create index("tweets", [:tweet_id], unique: true)
   end
 end

--- a/ex_feels/priv/repo/migrations/20171215022041_create_table_users.exs
+++ b/ex_feels/priv/repo/migrations/20171215022041_create_table_users.exs
@@ -15,6 +15,6 @@ defmodule ExFeels.Repo.Migrations.CreateTableUsers do
       timestamps()
     end
 
-    unique_index("users", [:user_id])
+    create index("users", [:user_id], unique: true)
   end
 end

--- a/ex_feels/priv/repo/migrations/20180204193349_alter_tweets_modify_text_size.exs
+++ b/ex_feels/priv/repo/migrations/20180204193349_alter_tweets_modify_text_size.exs
@@ -1,9 +1,0 @@
-defmodule ExFeels.Repo.Migrations.AlterTweetsModifyTextSize do
-  use Ecto.Migration
-
-  def change do
-    alter table("tweets") do
-      modify :text, :string, size: 300
-    end
-  end
-end


### PR DESCRIPTION
The `unique_index` shortcut did not create a unique index in the database.