### PR TITLE
stop, yaml time

### DIFF
--- a/py_feels/binary/time_series.py
+++ b/py_feels/binary/time_series.py
@@ -14,7 +14,6 @@ env is "dev" or "prod"
 """
 
 # constant window width
-WINDOW = 24
 
 import pandas as pd
 from dateutil import parser
@@ -23,6 +22,11 @@ from datetime import datetime
 from sys import argv
 from math import ceil
 from sqlalchemy import create_engine
+import yaml
+
+with open('time_series.yaml') as f:
+    settings = yaml.load(f)
+    WINDOW = settings['WINDOW']
 
 # check environment, parse arguments
 if len(argv) < 2 or argv[1] == "dev":

--- a/py_feels/binary/time_series.yaml
+++ b/py_feels/binary/time_series.yaml
@@ -1,0 +1,3 @@
+{
+  'WINDOW' : 168 # 168 hours = one week
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31669884/39411310-93f0ebb6-4bd5-11e8-941b-4e7867ea44b3.png)
#
 # bitfeels ain't dead

- praise be unto RMS
- use `yaml` for setting `time_series.py` window
- bump window to 1 week, 168 hours