### PR TITLE
Fire / Report Tweet Events

### DIFF
--- a/lib/bitfeels/application.ex
+++ b/lib/bitfeels/application.ex
@@ -2,7 +2,11 @@ defmodule Bitfeels.Application do
   use Application
 
   def start(_type, _args) do
-    sink = Application.get_env(:bitfeels, :twitter_stream)[:sink] || self()
+    stream_opts = Application.get_env(:bitfeels, :twitter_stream)
+
+    tweet_sink = stream_opts[:tweet_sink] || self()
+    metric_sink = stream_opts[:metric_sink] || self()
+
     events = [
       [:bitfeels, :pipeline, :source],
       [:bitfeels, :pipeline, :sentiment]
@@ -12,9 +16,9 @@ defmodule Bitfeels.Application do
       {Registry, keys: :unique, name: Registry.Streams},
       {Bitfeels.Pipeline.Source, []},
       {Bitfeels.Pipeline.Dispatcher, []},
-      {Bitfeels.Pipeline.Sentiment, [sink: sink]},
+      {Bitfeels.Pipeline.Sentiment, [sink: tweet_sink]},
       {Bitfeels.StreamSupervisor, []},
-      {Bitfeels.Reporter, [events: events]}
+      {Bitfeels.Reporter, [events: events, sink: metric_sink]}
     ]
 
     opts = [strategy: :one_for_one, name: Bitfeels.Supervisor]

--- a/lib/bitfeels/application.ex
+++ b/lib/bitfeels/application.ex
@@ -3,6 +3,10 @@ defmodule Bitfeels.Application do
 
   def start(_type, _args) do
     sink = Application.get_env(:bitfeels, :twitter_stream)[:sink] || self()
+    events = [
+      [:bitfeels, :pipeline, :source],
+      [:bitfeels, :pipeline, :sentiment]
+    ]
 
     children = [
       {Registry, keys: :unique, name: Registry.Streams},
@@ -10,6 +14,7 @@ defmodule Bitfeels.Application do
       {Bitfeels.Pipeline.Dispatcher, []},
       {Bitfeels.Pipeline.Sentiment, [sink: sink]},
       {Bitfeels.StreamSupervisor, []},
+      {Bitfeels.Reporter, [events: events]}
     ]
 
     opts = [strategy: :one_for_one, name: Bitfeels.Supervisor]

--- a/lib/bitfeels/pipeline/sentiment.ex
+++ b/lib/bitfeels/pipeline/sentiment.ex
@@ -21,6 +21,10 @@ defmodule Bitfeels.Pipeline.Sentiment do
   end
 
   defp send_tweet_message(tweet, opts) do
+    measurements = %{id: tweet["id"], score: tweet["score"]}
+    metadata = %{time: System.os_time(:millisecond)}
+    :telemetry.execute([:bitfeels, :pipeline, :sentiment], measurements, metadata)
+
     send(opts[:sink], {:tweet, {tweet["id"], tweet}})
   end
 end

--- a/lib/bitfeels/pipeline/source.ex
+++ b/lib/bitfeels/pipeline/source.ex
@@ -10,7 +10,16 @@ defmodule Bitfeels.Pipeline.Source do
   end
 
   def handle_info({:tweet, event}, :ok) do
+    fire_metric_event(event)
+
     :ok = Bitfeels.Pipeline.Dispatcher.notify(event)
+
     {:noreply, :ok}
+  end
+
+  defp fire_metric_event(%{"id" => id}) do
+    measurements = %{id: id}
+    metadata = %{time: System.os_time(:millisecond)}
+    :telemetry.execute([:bitfeels, :pipeline, :source], measurements, metadata)
   end
 end

--- a/lib/bitfeels/reporter.ex
+++ b/lib/bitfeels/reporter.ex
@@ -1,0 +1,41 @@
+defmodule Bitfeels.Reporter do
+  use GenServer
+  require Logger
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts[:events])
+  end
+
+  def init(events) do
+    :ets.new(:bitfeels_events, [:named_table, :public, :bag, {:write_concurrency, true}])
+
+    :telemetry.attach_many("bitfeels-reporter", events, &handle_event/4, nil)
+
+    {:ok, events}
+  end
+
+  defp handle_event([:bitfeels, :pipeline, :source] = event, measurements, metadata, _config) do
+    data = {
+      event_key(event),
+      measurements.id,
+      metadata.time
+    }
+
+    :ets.insert(:bitfeels_events, data)
+  end
+
+  defp handle_event([:bitfeels, :pipeline, :sentiment] = event, measurements, metadata, _config) do
+    data = {
+      event_key(event),
+      measurements.id,
+      measurements.score,
+      metadata.time,
+    }
+
+    :ets.insert(:bitfeels_events, data)
+  end
+
+  defp event_key(event_name) do
+    event_name |> Enum.map(&Atom.to_string/1) |> Enum.join("_")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule Bitfeels.MixProject do
       {:gen_stage, "~> 0.14"},
       {:hackney, "~> 1.14.3"},
       {:jason, "~> 1.1"},
+      {:telemetry, "~> 0.4.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.14.0-rc.1", "a88cbeab25c5f3fc505fc6590bd30877a5acf11b448aedb23b41cbc063824ceb", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.0-rc.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
-  "telemetry": {:hex, :telemetry, "0.2.0", "5b40caa3efe4deb30fb12d7cd8ed4f556f6d6bd15c374c2366772161311ce377", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
   "twitter_stream": {:hex, :twitter_stream, "0.2.3", "f25949d25034744ed535ca08ab704b52684a35f29386dfb7ed110406539567a3", [:mix], [{:hackney, "~> 1.14.3", [hex: :hackney, repo: "hexpm", optional: false]}, {:jsx, "~> 2.9", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
* Adds telemetry
* Fire events on new tweets and tweets with sentiment
* Adds reporter process that handles incoming events
* Sends data to a process upstream (SenTweet.Metrics)